### PR TITLE
Add Ritn3D to 3D Printing > Helpful Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A curated list of awesome [Maker](https://en.wikipedia.org/wiki/Maker_culture) R
 * [TinkerCAD](https://www.tinkercad.com/) - A simple-to-use 3D modeling software in your browser
 * [OpenSCAD](https://www.openscad.org/) - free and open source software script-only application for creating solid 3D CAD objects
 * [Terrain2STL](http://jthatch.com/Terrain2STL/) - Convert real-world map data to 3D-printable STLs
+* [Ritn3D](https://www.ritn3d.com/) - Convert a 2D floor plan (PDF, JPG, PNG) into a 3D printable house model. Auto-detects walls, doors, windows, and rooms; exports a manifold STL with sealed walls and a flat base ready for any slicer at 1:100 or 1:50 scale.
 
 ### Troubleshooting
 * [Matterhackers Troubleshooting Guide](https://www.matterhackers.com/articles/3d-printer-troubleshooting-guide) - A general 3D printing troubleshooting guide


### PR DESCRIPTION
Ritn3D is useful for makers who want to 3D print miniature house models from a 2D floor plan. It takes a PDF, JPG, or PNG of a floor plan, auto-detects walls / doors / windows / rooms, and exports a manifold STL with sealed walls and a flat base — ready for any slicer at 1:100 or 1:50 scale (typical hobbyist scales for architectural prints).

- Web app, iOS, Android
- Free tier (no STL export); STL export in Pro+ tier ($19.99/mo, 10 downloads/mo + rollover credits)
- Output is print-ready, no mesh repair needed

Fits well alongside Terrain2STL — same pattern (real-world input → printable STL), different domain (floor plans instead of terrain).